### PR TITLE
Fix catkin devel-space include dirs

### DIFF
--- a/CMake/AbseilCatkin.cmake
+++ b/CMake/AbseilCatkin.cmake
@@ -21,6 +21,7 @@ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 ## catkin package configuration
 catkin_package(
   CFG_EXTRAS ${PROJECT_SOURCE_DIR}/CMake/abseil_cpp-catkin-extras.cmake
+  INCLUDE_DIRS .
 )
 
 ## Restore original project 'absl'


### PR DESCRIPTION
The include directories were neither installed nor exported via `catkin_package(INCLUDE_DIRS ...)` when building the package in devel-space with catkin.